### PR TITLE
Race between response headers and window updates

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/client.rpt
@@ -66,6 +66,17 @@ write [0x00 0x00 0x1e]                  # length = 30
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# first response HEADERS stream_id = 1
+read [0x00 0x00 0x58]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x02] "15"                               # content-length
+
 # Second request HEADERS for /style.css stream_id = 3
 write [0x00 0x00 0x1e]                  # length = 30
       [0x01]                            # HEADERS frame
@@ -76,6 +87,19 @@ write [0x00 0x00 0x1e]                  # length = 30
       [0x04] [0x0a] "/style.css"        # :path: /style.css
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
+
+# second response HEADERS stream_id = 3
+read [0x00 0x00 0x58]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x03]                                 # stream_id=3
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x02] "31"                               # content-length
+
+
 
 write [0x00 0x00 0x0c]                  # length = 12
       [0x00]                            # HTTP2 DATA frame
@@ -97,6 +121,16 @@ read [0x00 0x00 0x04]                                      # length
      [0x00 0x00 0x00 0x01]                                 # stream_id=1
      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
+# first response DATA stream_id = 1
+read [0x00 0x00 0x0f]                          # length = 15
+     [0x00]                                    # HTTP2 DATA frame
+     [0x00]                                    # no flags
+     [0x00 0x00 0x00 0x01]                     # stream_id=1
+     "function f() {"
+     "}"
+
+
+
 write [0x00 0x00 0x13]                  # length = 28
       [0x00]                            # HTTP2 DATA frame
       [0x01]                            # END_STREAM
@@ -116,36 +150,6 @@ read [0x00 0x00 0x04]                                      # length
      [0x00]                                                # no flags
      [0x00 0x00 0x00 0x03]                                 # stream_id=1
      [0x00 0x00 0x00 0x13]                                 # window size increment = 19
-
-# first response HEADERS stream_id = 1
-read [0x00 0x00 0x58]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x02] "15"                               # content-length
-
-# second response HEADERS stream_id = 3
-read [0x00 0x00 0x58]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x03]                                 # stream_id=3
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x02] "31"                               # content-length
-
-# first response DATA stream_id = 1
-read [0x00 0x00 0x0f]                          # length = 15
-     [0x00]                                    # HTTP2 DATA frame
-     [0x00]                                    # no flags
-     [0x00 0x00 0x00 0x01]                     # stream_id=1
-     "function f() {"
-     "}"
 
 # second response DATA on stream_id = 3
 read [0x00 0x00 0x15]                          # length = 31

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/server.rpt
@@ -64,6 +64,17 @@ read [0x00 0x00 0x1e]                   # length = 30
      [0x04] [0x0a] "/script.js"         # :path: /script.js
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+write [0x00 0x00 0x58]                                      # length
+      [0x01]                                                # HTTP2 HEADERS frame
+      [0x04]                                                # END_HEADERS
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x88]                                                # :status: 200
+      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+      [0x0f 0x0d] [0x02] "15"                               # content-length
+write flush
+
 read [0x00 0x00 0x1e]                   # length = 30
      [0x01]                             # HEADERS frame
      [0x04]                             # END_HEADERS
@@ -72,6 +83,19 @@ read [0x00 0x00 0x1e]                   # length = 30
      [0x86]                             # :scheme: http
      [0x04] [0x0a] "/style.css"         # :path: /style.css
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+write [0x00 0x00 0x58]                                      # length
+      [0x01]                                                # HTTP2 HEADERS frame
+      [0x04]                                                # END_HEADERS
+      [0x00 0x00 0x00 0x03]                                 # stream_id=3
+      [0x88]                                                # :status: 200
+      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+      [0x0f 0x0d] [0x02] "31"                               # content-length
+write flush
+
+
 
 read [0x00 0x00 0x0c]                   # length = 12
      [0x00]                             # HTTP2 DATA frame
@@ -85,12 +109,25 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x00]                                 # stream_id=0
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
+write flush
+
 # stream-level flow control
 write [0x00 0x00 0x04]                                      # length
       [0x08]                                                # WINDOW_UPDATE frame
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x01]                                 # stream_id=1
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
+write flush
+
+write [0x00 0x00 0x0f]                  # length = 15
+      [0x00]                            # HTTP2 DATA frame
+      [0x00]                            # no flags
+      [0x00 0x00 0x00 0x01]             # stream_id=1
+      "function f() {"
+      "}"
+write flush
+
+
 
 read [0x00 0x00 0x13]                   # length = 19
      [0x00]                             # HTTP2 DATA frame
@@ -104,41 +141,13 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x00]                                 # stream_id=0
       [0x00 0x00 0x00 0x13]                                 # window size increment = 19
+write flush
 # stream-level flow control
 write [0x00 0x00 0x04]                                      # length
       [0x08]                                                # WINDOW_UPDATE frame
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x03]                                 # stream_id=1
       [0x00 0x00 0x00 0x13]                                 # window size increment = 19
-
-write [0x00 0x00 0x58]                                      # length
-      [0x01]                                                # HTTP2 HEADERS frame
-      [0x04]                                                # END_HEADERS
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x88]                                                # :status: 200
-      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-      [0x0f 0x0d] [0x02] "15"                               # content-length
-write flush
-
-write [0x00 0x00 0x58]                                      # length
-      [0x01]                                                # HTTP2 HEADERS frame
-      [0x04]                                                # END_HEADERS
-      [0x00 0x00 0x00 0x03]                                 # stream_id=3
-      [0x88]                                                # :status: 200
-      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-      [0x0f 0x0d] [0x02] "31"                               # content-length
-write flush
-
-write [0x00 0x00 0x0f]                  # length = 15
-      [0x00]                            # HTTP2 DATA frame
-      [0x00]                            # no flags
-      [0x00 0x00 0x00 0x01]             # stream_id=1
-      "function f() {"
-      "}"
 write flush
 
 write [0x00 0x00 0x15]                  # length = 31

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/client.rpt
@@ -65,6 +65,16 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+read [0x00 0x00 0x59]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x03] "113"                              # content-length
+
 write [0x00 0x00 0x0c]                  # length = 12
       [0x00]                            # HTTP2 DATA frame
       [0x01]                            # END_STREAM
@@ -84,16 +94,6 @@ read [0x00 0x00 0x04]                                      # length
      [0x00]                                                # no flags
      [0x00 0x00 0x00 0x01]                                 # stream_id=1
      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-read [0x00 0x00 0x59]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x03] "113"                              # content-length
 
 read [0x00 0x00 0x71]                          # length = 113
      [0x00]                                    # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/server.rpt
@@ -64,6 +64,17 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+write [0x00 0x00 0x59]                                      # length
+      [0x01]                                                # HTTP2 HEADERS frame
+      [0x04]                                                # END_HEADERS
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x88]                                                # :status: 200
+      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+      [0x0f 0x0d] [0x03] "113"                              # content-length
+write flush
+
 read [0x00 0x00 0x0c]                   # length = 12
      [0x00]                             # HTTP2 DATA frame
      [0x01]                             # END_STREAM
@@ -82,17 +93,6 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x01]                                 # stream_id=1
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-write [0x00 0x00 0x59]                                      # length
-      [0x01]                                                # HTTP2 HEADERS frame
-      [0x04]                                                # END_HEADERS
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x88]                                                # :status: 200
-      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-      [0x0f 0x0d] [0x03] "113"                              # content-length
-write flush
 
 write [0x00 0x00 0x71]                  # length = 113
       [0x00]                            # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/client.rpt
@@ -66,6 +66,16 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+read [0x00 0x00 0x59]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x03] "113"                              # content-length
+
 write [0x00 0x00 0x0c]                  # length = 12
       [0x00]                            # HTTP2 DATA frame
       [0x01]                            # END_STREAM
@@ -85,16 +95,6 @@ read [0x00 0x00 0x04]                                      # length
      [0x00]                                                # no flags
      [0x00 0x00 0x00 0x01]                                 # stream_id=1
      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-read [0x00 0x00 0x59]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x03] "113"                              # content-length
 
 # First http2 PUSH_PROMISE frame
 read [0x00 0x00 0x22]                          # length = 35

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/server.rpt
@@ -65,6 +65,17 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+write [0x00 0x00 0x59]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x03] "113"                              # content-length
+write flush
+
 read [0x00 0x00 0x0c]                   # length = 12
      [0x00]                             # HTTP2 DATA frame
      [0x01]                             # END_STREAM
@@ -77,22 +88,14 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x00]                                 # stream_id=0
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
+write flush
+
 # stream-level flow control
 write [0x00 0x00 0x04]                                      # length
       [0x08]                                                # WINDOW_UPDATE frame
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x01]                                 # stream_id=1
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-write [0x00 0x00 0x59]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x03] "113"                              # content-length
 write flush
 
 # First http2 PUSH_PROMISE frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/client.rpt
@@ -57,34 +57,13 @@ write flush
 
 write [0x00 0x00 0x13]                  # length = 19
       [0x01]                            # HEADERS frame
-      [0x04]                            # END_HEADERS
+      [0x05]                            # END_HEADERS | END_STREAM
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       [0x83]                            # :method: POST
       [0x86]                            # :scheme: http
       [0x84]                            # :path: /
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
-
-write [0x00 0x00 0x0c]                  # length = 12
-      [0x00]                            # HTTP2 DATA frame
-      [0x01]                            # END_STREAM
-      [0x00 0x00 0x00 0x01]             # stream_id = 1
-      "Hello, world"
-write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/server.rpt
@@ -57,32 +57,12 @@ read [0x00 0x00 0x00]                   # length = 0
 
 read [0x00 0x00 0x13]                   # length = 19
      [0x01]                             # HEADERS frame
-     [0x04]                             # END_HEADERS
+     [0x05]                             # END_HEADERS | END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      [0x83]                             # :method: POST
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
-
-read [0x00 0x00 0x0c]                   # length = 12
-     [0x00]                             # HTTP2 DATA frame
-     [0x01]                             # END_STREAM
-     [0x00 0x00 0x00 0x01]              # stream_id = 1
-     "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
@@ -58,33 +58,13 @@ write flush
 # First client-initiated request stream-id=1
 write [0x00 0x00 0x13]                  # length = 19
       [0x01]                            # HEADERS frame
-      [0x04]                            # END_HEADERS
+      [0x05]                            # END_HEADERS | END_STREAM
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       [0x83]                            # :method: POST
       [0x86]                            # :scheme: http
       [0x84]                            # :path: /
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
-
-write [0x00 0x00 0x0c]                  # length = 12
-      [0x00]                            # HTTP2 DATA frame
-      [0x01]                            # END_STREAM
-      [0x00 0x00 0x00 0x01]             # stream_id = 1
-      "Hello, world"
-write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 # Second client-initiated request stream-id=3
 write [0x00 0x00 0x19]                  # length = 25

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
@@ -58,31 +58,12 @@ read [0x00 0x00 0x00]                   # length = 0
 # First client-initiated request stream-id=1
 read [0x00 0x00 0x13]                   # length = 19
      [0x01]                             # HEADERS frame
-     [0x04]                             # END_HEADERS
+     [0x05]                             # END_HEADERS | END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      [0x83]                             # :method: POST
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
-
-read [0x00 0x00 0x0c]                   # length = 12
-     [0x00]                             # HTTP2 DATA frame
-     [0x01]                             # END_STREAM
-     [0x00 0x00 0x00 0x01]              # stream_id = 1
-     "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 # Second client-initiated request stream-id=3
 read [0x00 0x00 0x19]                  # length = 25

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/client.rpt
@@ -65,6 +65,16 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+read [0x00 0x00 0x59]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x03] "113"                              # content-length
+
 write [0x00 0x00 0x0c]                  # length = 12
       [0x00]                            # HTTP2 DATA frame
       [0x01]                            # END_STREAM
@@ -83,16 +93,6 @@ read [0x00 0x00 0x04]                                      # length
      [0x00]                                                # no flags
      [0x00 0x00 0x00 0x01]                                 # stream_id=1
      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-read [0x00 0x00 0x59]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x03] "113"                              # content-length
 
 write [0x00 0x00 0x04]                          # length = 113
       [0x03]                                    # HTTP2 RST_STREAM frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/server.rpt
@@ -64,6 +64,17 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+write [0x00 0x00 0x59]                                      # length
+      [0x01]                                                # HTTP2 HEADERS frame
+      [0x04]                                                # END_HEADERS
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x88]                                                # :status: 200
+      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+      [0x0f 0x0d] [0x03] "113"                              # content-length
+write flush
+
 read [0x00 0x00 0x0c]                   # length = 12
      [0x00]                             # HTTP2 DATA frame
      [0x01]                             # END_STREAM
@@ -75,22 +86,13 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x00]                                 # stream_id=0
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
+write flush
 
 write [0x00 0x00 0x04]                                      # length
       [0x08]                                                # WINDOW_UPDATE frame
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x01]                                 # stream_id=1
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-write [0x00 0x00 0x59]                                      # length
-      [0x01]                                                # HTTP2 HEADERS frame
-      [0x04]                                                # END_HEADERS
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x88]                                                # :status: 200
-      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-      [0x0f 0x0d] [0x03] "113"                              # content-length
 write flush
 
 read [0x00 0x00 0x04]                          # length = 4

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/client.rpt
@@ -65,6 +65,16 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+read [0x00 0x00 0x59]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x03] "113"                              # content-length
+
 write [0x00 0x00 0x0c]                  # length = 12
       [0x00]                            # HTTP2 DATA frame
       [0x01]                            # END_STREAM
@@ -84,16 +94,6 @@ read [0x00 0x00 0x04]                                      # length
      [0x00]                                                # no flags
      [0x00 0x00 0x00 0x01]                                 # stream_id=1
      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-read [0x00 0x00 0x59]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x03] "113"                              # content-length
 
 read [0x00 0x00 0x3c]                          # length = 60
      [0x00]                                    # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/server.rpt
@@ -64,6 +64,17 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+write [0x00 0x00 0x59]                                      # length
+      [0x01]                                                # HTTP2 HEADERS frame
+      [0x04]                                                # END_HEADERS
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x88]                                                # :status: 200
+      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+      [0x0f 0x0d] [0x03] "113"                              # content-length
+write flush
+
 read [0x00 0x00 0x0c]                   # length = 12
      [0x00]                             # HTTP2 DATA frame
      [0x01]                             # END_STREAM
@@ -76,22 +87,14 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x00]                                 # stream_id=0
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
+write flush
+
 # stream-level flow control
 write [0x00 0x00 0x04]                                      # length
       [0x08]                                                # WINDOW_UPDATE frame
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x01]                                 # stream_id=1
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-write [0x00 0x00 0x59]                                      # length
-      [0x01]                                                # HTTP2 HEADERS frame
-      [0x04]                                                # END_HEADERS
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x88]                                                # :status: 200
-      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-      [0x0f 0x0d] [0x03] "113"                              # content-length
 write flush
 
 write [0x00 0x00 0x3c]                          # length = 60

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/client.rpt
@@ -75,6 +75,19 @@ write [0x00 0x00 0x11]                  # length = 17
 write flush
 
 #
+# response HEADERS frame
+#
+read [0x00 0x00 0x59]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x03] "113"                              # content-length
+
+#
 # request body DATA frame
 #
 write [0x00 0x00 0x0c]                  # length = 12
@@ -97,19 +110,6 @@ read [0x00 0x00 0x04]                                      # length
      [0x00]                                                # no flags
      [0x00 0x00 0x00 0x01]                                 # stream_id=1
      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-#
-# response HEADERS frame
-#
-read [0x00 0x00 0x59]                                      # length
-     [0x01]                                                # HTTP2 HEADERS frame
-     [0x04]                                                # END_HEADERS
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x88]                                                # :status: 200
-     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-     [0x0f 0x0d] [0x03] "113"                              # content-length
 
 #
 # response DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/server.rpt
@@ -73,6 +73,20 @@ read [0x00 0x00 0x11]                   # length = 17
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
 #
+# response headers using HEADERS frame
+#
+write [0x00 0x00 0x59]                                      # length
+      [0x01]                                                # HTTP2 HEADERS frame
+      [0x04]                                                # END_HEADERS
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x88]                                                # :status: 200
+      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+      [0x0f 0x0d] [0x03] "113"                              # content-length
+write flush
+
+#
 # request body using DATA frame
 #
 read [0x00 0x00 0x0c]                   # length = 12
@@ -87,6 +101,7 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x00]                                 # stream_id=0
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
+write flush
 
 # stream-level flow control
 write [0x00 0x00 0x04]                                      # length
@@ -94,19 +109,6 @@ write [0x00 0x00 0x04]                                      # length
       [0x00]                                                # no flags
       [0x00 0x00 0x00 0x01]                                 # stream_id=1
       [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-#
-# response headers using HEADERS frame
-#
-write [0x00 0x00 0x59]                                      # length
-      [0x01]                                                # HTTP2 HEADERS frame
-      [0x04]                                                # END_HEADERS
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x88]                                                # :status: 200
-      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
-      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
-      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
-      [0x0f 0x0d] [0x03] "113"                              # content-length
 write flush
 
 #

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/multiple.data.frames/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/multiple.data.frames/client.rpt
@@ -36,9 +36,6 @@ read nukleus:begin.ext [0x00] [0x07] ":status" [0x03] "200"
 
 connected
 
-write "Hello, world"
-write flush
-
 read "<html>"
      "<head><link rel=\"stylesheet\" href=\"styles.css\"></head>"
 

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/multiple.data.frames/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/multiple.data.frames/server.rpt
@@ -36,8 +36,6 @@ write nukleus:begin.ext [0x00] [0x07] ":status" [0x03] "200"
 
 connected
 
-read "Hello, world"
-
 write "<html>"
       "<head><link rel=\"stylesheet\" href=\"styles.css\"></head>"
 write flush

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
@@ -39,8 +39,6 @@ read nukleus:begin.ext [0x00] [0x07] ":status" [0x03] "200"
 
 connected
 
-write "Hello, world"
-write flush
 
 # First push promise
 read nukleus:data.ext [0x00] [0x07] ":method" [0x03] "GET"

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
@@ -40,8 +40,6 @@ write nukleus:begin.ext [0x00] [0x07] ":status" [0x03] "200"
 
 connected
 
-read "Hello, world"
-
 write await SECOND_REQUEST_RECEIVED
 
 # First push promise


### PR DESCRIPTION
There is a race between response headers and window updates for request payload.
Fixing this by sequencing the order: request headers, response headers, request payload, response
payload