### PR TITLE
Test for nukleus DATA frame max size

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/client.rpt
@@ -1,0 +1,95 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newServerAcceptRef ${nukleus:newRouteRef()} # external
+
+connect await ROUTED_SERVER
+        "nukleus://http2/streams/source"
+        option nukleus:route ${newServerAcceptRef}
+        option nukleus:window 65536
+        option nukleus:transmission "duplex"
+connected
+
+# client connection preface
+write "PRI * HTTP/2.0\r\n"
+      "\r\n"
+      "SM\r\n"
+      "\r\n"
+write flush
+
+# server connection preface - SETTINGS frame
+read [0x00 0x00 0x06]                   # length = 6
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x00]                             # flags = 0x00
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+     [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+
+write [0x00 0x00 0x0c]                   # length = 12
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x04 0x00 0x00 0xff 0xf7]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 65527
+      [0x00 0x05 0x00 0x00 0xff 0xf7]    # SETTINGS_MAX_FRAME_SIZE(0x05) = 65527
+write flush
+
+read [0x00 0x00 0x00]                   # length = 0
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x01]                             # ACK
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+
+write [0x00 0x00 0x00]                  # length = 0
+      [0x04]                            # HTTP2 SETTINGS frame
+      [0x01]                            # ACK
+      [0x00 0x00 0x00 0x00]             # stream_id = 0
+write flush
+
+#
+# request headers with HEADERS frames
+#
+write [0x00 0x00 0x13]                  # length = 19
+      [0x01]                            # HEADERS frame
+      [0x05]                            # END_HEADERS | END_STREAM
+      [0x00 0x00 0x00 0x01]             # stream_id = 1
+      [0x82]                            # :method: GET
+      [0x86]                            # :scheme: http
+      [0x84]                            # :path: /
+      [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
+write flush
+
+#
+# response HEADERS frame
+#
+read [0x00 0x00 0x5b]                                      # length
+     [0x01]                                                # HTTP2 HEADERS frame
+     [0x04]                                                # END_HEADERS
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x88]                                                # :status: 200
+     [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+     [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+     [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+     [0x0f 0x0d] [0x05] "65527"                            # content-length
+
+#
+# comes in two nuklei DATA frames
+# response HTTP2 DATA frame
+#
+read [0x00 0xff 0xf7]                          # length = 65527
+     [0x00]                                    # HTTP2 DATA frame
+     [0x00]                                    # no flags
+     [0x00 0x00 0x00 0x01]                     # stream_id=1
+read [0..65527]
+
+

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/server.rpt
@@ -1,0 +1,96 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newServerAcceptRef ${nukleus:newRouteRef()} # external
+property data ${http2:randomBytes(65527)}
+
+accept await ROUTED_SERVER
+       "nukleus://http2/streams/source"
+       option nukleus:route ${newServerAcceptRef}
+       option nukleus:window 65536
+       option nukleus:transmission "duplex"
+accepted
+connected
+
+# client connection preface
+read "PRI * HTTP/2.0\r\n"
+      "\r\n"
+      "SM\r\n"
+      "\r\n"
+
+# server connection preface - SETTINGS frame
+write [0x00 0x00 0x06]                   # length = 6
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x00]                             # flags = 0x00
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+write flush
+
+read [0x00 0x00 0x0c]                   # length = 12
+     [0x04]                             # HTTP2 SETTINGS frame
+     [0x00]                             # flags = 0x00
+     [0x00 0x00 0x00 0x00]              # stream_id = 0
+     [0x00 0x04 0x00 0x00 0xff 0xf7]    # SETTINGS_INITIAL_WINDOW_SIZE(0x04) = 65527
+     [0x00 0x05 0x00 0x00 0xff 0xf7]    # SETTINGS_MAX_FRAME_SIZE(0x05) = 65527
+
+write [0x00 0x00 0x00]                   # length = 0
+      [0x04]                             # HTTP2 SETTINGS frame
+      [0x01]                             # ACK
+      [0x00 0x00 0x00 0x00]              # stream_id = 0
+write flush
+
+read [0x00 0x00 0x00]                  # length = 0
+     [0x04]                            # HTTP2 SETTINGS frame
+     [0x01]                            # ACK
+     [0x00 0x00 0x00 0x00]             # stream_id = 0
+
+#
+# request headers with HEADERS frames
+#
+read [0x00 0x00 0x13]                  # length = 19
+     [0x01]                            # HEADERS frame
+     [0x05]                            # END_HEADERS | END_STREAM
+     [0x00 0x00 0x00 0x01]             # stream_id = 1
+     [0x82]                            # :method: GET
+     [0x86]                            # :scheme: http
+     [0x84]                            # :path: /
+     [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
+
+#
+# response HEADERS frame
+#
+write [0x00 0x00 0x5b]                                      # length
+      [0x01]                                                # HTTP2 HEADERS frame
+      [0x04]                                                # END_HEADERS
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x88]                                                # :status: 200
+      [0x0f 0x27] [0x14] "CERN/3.0 libwww/2.17"             # server
+      [0x0f 0x12] [0x1d] "Wed, 01 Feb 2017 19:12:46 GMT"    # date
+      [0x0f 0x10] [0x18] "text/html; charset=UTF-8"         # content-type
+      [0x0f 0x0d] [0x05] "65527"                            # content-length
+write flush
+
+#
+# response DATA frame
+#
+write [0x00 0xff 0xf7]                          # length = 65527
+      [0x00]                                    # HTTP2 DATA frame
+      [0x00]                                    # no flags
+      [0x00 0x00 0x00 0x01]                     # stream_id=1
+write ${data}
+write flush
+
+

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/message.format/max.nukleus.data.frame.size/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/message.format/max.nukleus.data.frame.size/client.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newServerConnectRef ${nuklei:newReferenceId()} # external scope
+
+connect await ROUTED_SERVER
+        "nukleus://target/streams/http2"
+        option nukleus:route ${newServerConnectRef}
+        option nukleus:window 65536
+        option nukleus:transmission "duplex"
+
+
+write nukleus:begin.ext ${http:header(":method", "GET")}
+                        ${http:header(":scheme", "http")}
+                        ${http:header(":path", "/")}
+                        ${http:header(":authority", "localhost:8080")}
+
+read nukleus:begin.ext ${http:header(":status", "200")}
+                       ${http:header("server", "CERN/3.0 libwww/2.17")}
+                       ${http:header("date", "Wed, 01 Feb 2017 19:12:46 GMT")}
+                       ${http:header("content-type", "text/html; charset=UTF-8")}
+                       ${http:header("content-length", "65527")}
+
+connected
+
+write "Hello, world"
+write flush
+
+read [0..65527]

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/message.format/max.nukleus.data.frame.size/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/message.format/max.nukleus.data.frame.size/server.rpt
@@ -1,0 +1,42 @@
+#
+# Copyright 2016-2017 The Reaktivity Project
+#
+# The Reaktivity Project licenses this file to you under the Apache License,
+# version 2.0 (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+property newServerConnectRef ${nuklei:newReferenceId()} # external scope
+property data ${http2:randomBytes(65527)}
+
+
+accept await ROUTED_SERVER
+        "nukleus://target/streams/http2"
+        option nukleus:route ${newServerConnectRef}
+        option nukleus:window 65536
+        option nukleus:transmission "duplex"
+accepted
+
+read nukleus:begin.ext ${http:header(":method", "GET")}
+                       ${http:header(":scheme", "http")}
+                       ${http:header(":path", "/")}
+                       ${http:header(":authority", "localhost:8080")}
+
+write nukleus:begin.ext ${http:header(":status", "200")}
+                        ${http:header("server", "CERN/3.0 libwww/2.17")}
+                        ${http:header("date", "Wed, 01 Feb 2017 19:12:46 GMT")}
+                        ${http:header("content-type", "text/html; charset=UTF-8")}
+                        ${http:header("content-length", "65527")}
+
+connected
+
+write ${data}
+write flush

--- a/src/test/java/org/reaktivity/specification/http2/rfc7540/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/specification/http2/rfc7540/MessageFormatIT.java
@@ -74,6 +74,18 @@ public class MessageFormatIT
 
     @Test
     @Specification({
+            "${spec}/max.nukleus.data.frame.size/client",
+            "${spec}/max.nukleus.data.frame.size/server",
+    })
+    public void maxNukleusDataFrameSize() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
             "${spec}/connection.headers/client",
             "${spec}/connection.headers/server",
     })

--- a/src/test/java/org/reaktivity/specification/nukleus/http2/streams/rfc7540/MessageFormatIT.java
+++ b/src/test/java/org/reaktivity/specification/nukleus/http2/streams/rfc7540/MessageFormatIT.java
@@ -74,6 +74,18 @@ public class MessageFormatIT
 
     @Test
     @Specification({
+            "${nukleus}/max.nukleus.data.frame.size/client",
+            "${nukleus}/max.nukleus.data.frame.size/server"
+    })
+    public void maxNukleusDataFrameSize() throws Exception
+    {
+        k3po.start();
+        k3po.notifyBarrier("ROUTED_SERVER");
+        k3po.finish();
+    }
+
+    @Test
+    @Specification({
             "${nukleus}/connection.headers/client",
             "${nukleus}/connection.headers/server"
     })


### PR DESCRIPTION
Adding a test case where one http2 DATA frame is split into two nukleus
DATA frames (as the nukleus DATA frame length exceeds 2 bytes)