### PR TITLE
Aligning the HTTP2 request flow control with their corresponding HTTP streams

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.closed.request/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.closed.request/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -65,6 +66,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,19 +95,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 read abort
 

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.closed.request/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.closed.request/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -64,6 +65,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 12
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 12
+write flush
+
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -80,18 +95,5 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 write aborted

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.open.request/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.open.request/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -64,6 +65,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x84]                            # :path: /
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
+
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
 
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.open.request/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.read.abort.on.open.request/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -63,6 +64,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
 
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.closed.request/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.closed.request/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -65,6 +66,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,19 +95,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 write abort
 

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.closed.request/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.closed.request/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -64,6 +65,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -80,19 +95,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 read aborted
 

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.open.request/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.open.request/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -64,6 +65,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x84]                            # :path: /
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
+
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
 
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.open.request/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.abort.on.open.request/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -63,6 +64,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
 
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.close/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.close/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -64,6 +65,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x84]                            # :path: /
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
+
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
 
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.close/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/client.sent.write.close/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -63,6 +64,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
 
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.established/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.established/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.established/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.established/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -66,6 +67,19 @@ write [0x00 0x00 0x1e]                  # length = 30
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 # first response HEADERS stream_id = 1
 read [0x00 0x00 0x58]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
@@ -88,6 +102,20 @@ write [0x00 0x00 0x1e]                  # length = 30
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x03]                                 # stream_id=3
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
+
 # second response HEADERS stream_id = 3
 read [0x00 0x00 0x58]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
@@ -108,19 +136,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       "Hello, world"
 write flush
 
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
 # first response DATA stream_id = 1
 read [0x00 0x00 0x0f]                          # length = 15
      [0x00]                                    # HTTP2 DATA frame
@@ -137,19 +152,6 @@ write [0x00 0x00 0x13]                  # length = 28
       [0x00 0x00 0x00 0x03]             # stream_id = 3
       "Hello, world, again"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x13]                                 # window size increment = 19
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x03]                                 # stream_id=1
-     [0x00 0x00 0x00 0x13]                                 # window size increment = 19
 
 # second response DATA on stream_id = 3
 read [0x00 0x00 0x15]                          # length = 31

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/connection.has.two.streams/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -64,6 +65,20 @@ read [0x00 0x00 0x1e]                   # length = 30
      [0x04] [0x0a] "/script.js"         # :path: /script.js
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 write [0x00 0x00 0x58]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -84,6 +99,19 @@ read [0x00 0x00 0x1e]                   # length = 30
      [0x04] [0x0a] "/style.css"         # :path: /style.css
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x03]                                 # stream_id=3
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 write [0x00 0x00 0x58]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -103,22 +131,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
 
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
-
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
-
 write [0x00 0x00 0x0f]                  # length = 15
       [0x00]                            # HTTP2 DATA frame
       [0x00]                            # no flags
@@ -134,21 +146,6 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x03]              # stream_id = 3
      "Hello, world, again"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x13]                                 # window size increment = 19
-write flush
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x03]                                 # stream_id=1
-      [0x00 0x00 0x00 0x13]                                 # window size increment = 19
-write flush
 
 write [0x00 0x00 0x15]                  # length = 31
       [0x00]                            # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.get.exchange/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.get.exchange/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.get.exchange/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.get.exchange/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -65,6 +66,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,19 +95,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 read [0x00 0x00 0x71]                          # length = 113
      [0x00]                                    # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.post.exchange/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -64,6 +65,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -80,19 +95,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 write [0x00 0x00 0x71]                  # length = 113
       [0x00]                            # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -66,6 +67,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -82,19 +96,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 # First http2 PUSH_PROMISE frame
 read [0x00 0x00 0x22]                          # length = 35

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.push.promise/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -65,6 +66,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 write [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,22 +96,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
-
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
 
 # First http2 PUSH_PROMISE frame
 write [0x00 0x00 0x22]                          # length = 35

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.unknown.authority/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.unknown.authority/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.unknown.authority/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/http.unknown.authority/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/multiple.data.frames/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/push.promise.on.different.stream/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -65,6 +66,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,18 +95,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 write [0x00 0x00 0x04]                          # length = 113
       [0x03]                                    # HTTP2 RST_STREAM frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -63,6 +64,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
 
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.read.abort.on.open.request/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.read.abort.on.open.request/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -64,6 +65,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x84]                            # :path: /
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
+
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
 
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.read.abort.on.open.request/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.read.abort.on.open.request/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -63,6 +64,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
 
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.closed.request/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.closed.request/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -65,6 +66,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,19 +95,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 read [0x00 0x00 0x04]                           # length = 4
      [0x03]                                     # HTTP2 RST_STREAM frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.closed.request/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.closed.request/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -64,6 +65,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -80,22 +95,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
-
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
 
 write [0x00 0x00 0x04]                           # length = 4
       [0x03]                                     # HTTP2 RST_STREAM frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.open.request/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.open.request/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -64,6 +65,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x84]                            # :path: /
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
+
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
 
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.open.request/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.abort.on.open.request/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -63,6 +64,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x86]                             # :scheme: http
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
+
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
 
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.close/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.close/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -65,6 +66,19 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,19 +95,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 # HTTP2 stream_id=1 ends
 read [0x00 0x00 0x00]                  # length = 0

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.close/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/server.sent.write.close/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -64,6 +65,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -80,22 +95,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
-
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
 
 # HTTP2 stream_id=1 ends
 write [0x00 0x00 0x00]                  # length = 0

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -65,6 +66,20 @@ write [0x00 0x00 0x13]                  # length = 19
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 read [0x00 0x00 0x59]                                      # length
      [0x01]                                                # HTTP2 HEADERS frame
      [0x04]                                                # END_HEADERS
@@ -81,19 +96,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 read [0x00 0x00 0x3c]                          # length = 60
      [0x00]                                    # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/flow.control/stream.flow/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -64,6 +65,20 @@ read [0x00 0x00 0x13]                   # length = 19
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 write [0x00 0x00 0x59]                                      # length
       [0x01]                                                # HTTP2 HEADERS frame
       [0x04]                                                # END_HEADERS
@@ -80,22 +95,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
-
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
 
 write [0x00 0x00 0x3c]                          # length = 60
       [0x00]                                    # HTTP2 DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/connection.headers/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/connection.headers/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/connection.headers/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/connection.headers/server.rpt
@@ -34,11 +34,12 @@ read "PRI * HTTP/2.0\r\n"
       "\r\n"
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 read [0x00 0x00 0x06]                   # length = 6

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame
@@ -74,6 +75,19 @@ write [0x00 0x00 0x11]                  # length = 17
       [0x01] [0x0e] "localhost:8080"    # :authority: localhost:8080
 write flush
 
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+
 #
 # response HEADERS frame
 #
@@ -96,20 +110,6 @@ write [0x00 0x00 0x0c]                  # length = 12
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
-
-# connection-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x00]                                 # stream_id=0
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-
-# stream-level flow control
-read [0x00 0x00 0x04]                                      # length
-     [0x08]                                                # WINDOW_UPDATE frame
-     [0x00]                                                # no flags
-     [0x00 0x00 0x00 0x01]                                 # stream_id=1
-     [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
 
 #
 # response DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/continuation.frames/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface
@@ -72,6 +73,20 @@ read [0x00 0x00 0x11]                   # length = 17
      [0x84]                             # :path: /
      [0x01] [0x0e] "localhost:8080"     # :authority: localhost:8080
 
+# connection-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x00]                                 # stream_id=0
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+# stream-level flow control
+write [0x00 0x00 0x04]                                      # length
+      [0x08]                                                # WINDOW_UPDATE frame
+      [0x00]                                                # no flags
+      [0x00 0x00 0x00 0x01]                                 # stream_id=1
+      [0x00 0x00 0x20 0x00]                                 # window size increment = 8192
+write flush
+
 #
 # response headers using HEADERS frame
 #
@@ -94,22 +109,6 @@ read [0x00 0x00 0x0c]                   # length = 12
      [0x01]                             # END_STREAM
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
-
-# connection-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x00]                                 # stream_id=0
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
-
-# stream-level flow control
-write [0x00 0x00 0x04]                                      # length
-      [0x08]                                                # WINDOW_UPDATE frame
-      [0x00]                                                # no flags
-      [0x00 0x00 0x00 0x01]                                 # stream_id=1
-      [0x00 0x00 0x00 0x0c]                                 # window size increment = 12
-write flush
 
 #
 # response body using DATA frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/dynamic.table.requests/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/dynamic.table.requests/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x06]                   # length = 6
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/dynamic.table.requests/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/dynamic.table.requests/server.rpt
@@ -25,11 +25,12 @@ accepted
 connected
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 # client connection preface

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.frame.size/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.frame.size/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.frame.size/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.frame.size/server.rpt
@@ -34,11 +34,12 @@ read "PRI * HTTP/2.0\r\n"
       "\r\n"
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 read [0x00 0x00 0x0c]                   # length = 12

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/client.rpt
@@ -31,11 +31,12 @@ write "PRI * HTTP/2.0\r\n"
 write flush
 
 # server connection preface - SETTINGS frame
-read [0x00 0x00 0x06]                   # length = 6
+read [0x00 0x00 0x0c]                   # length = 12
      [0x04]                             # HTTP2 SETTINGS frame
      [0x00]                             # flags = 0x00
      [0x00 0x00 0x00 0x00]              # stream_id = 0
      [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+     [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 
 write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/message.format/max.nukleus.data.frame.size/server.rpt
@@ -32,11 +32,12 @@ read "PRI * HTTP/2.0\r\n"
       "\r\n"
 
 # server connection preface - SETTINGS frame
-write [0x00 0x00 0x06]                   # length = 6
+write [0x00 0x00 0x0c]                   # length = 12
       [0x04]                             # HTTP2 SETTINGS frame
       [0x00]                             # flags = 0x00
       [0x00 0x00 0x00 0x00]              # stream_id = 0
       [0x00 0x03 0x00 0x00 0x00 0x64]    # SETTINGS_MAX_CONCURRENT_STREAMS(0x03) = 100
+      [0x00 0x04 0x00 0x00 0x00 0x00]    # SETTINGS_INITIAL_WINDOW_SIZE(0x03) = 0
 write flush
 
 read [0x00 0x00 0x0c]                   # length = 12


### PR DESCRIPTION
Aligning the HTTP2 request flow control with their corresponding HTTP streams.

HTTP2 sends WINDOW_UPDATE frames whenever HTTP sends nukleus window update.