### PR TITLE
RST_STREAM should ABORT the highlevel http stream

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/client.rpt
@@ -91,10 +91,23 @@ read [0x00 0x00 0x59]                                      # length
 
 write [0x00 0x00 0x0c]                  # length = 12
       [0x00]                            # HTTP2 DATA frame
-      [0x01]                            # END_STREAM
+      [0x00]                            # no flags
       [0x00 0x00 0x00 0x01]             # stream_id = 1
       "Hello, world"
 write flush
+
+# connection-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x00]                                 # stream_id=0
+     [0..4]                                                # window size increment = 8192
+# stream-level flow control
+read [0x00 0x00 0x04]                                      # length
+     [0x08]                                                # WINDOW_UPDATE frame
+     [0x00]                                                # no flags
+     [0x00 0x00 0x00 0x01]                                 # stream_id=1
+     [0..4]                                                # window size increment = 8192
 
 write [0x00 0x00 0x04]                          # length = 113
       [0x03]                                    # HTTP2 RST_STREAM frame

--- a/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/http2/rfc7540/connection.management/reset.http2.stream/server.rpt
@@ -92,7 +92,7 @@ write flush
 
 read [0x00 0x00 0x0c]                   # length = 12
      [0x00]                             # HTTP2 DATA frame
-     [0x01]                             # END_STREAM
+     [0x00]                             # no flags
      [0x00 0x00 0x00 0x01]              # stream_id = 1
      "Hello, world"
 

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/reset.http2.stream/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/reset.http2.stream/client.rpt
@@ -37,5 +37,5 @@ read nukleus:begin.ext ${http:header(":status", "200")}
 connected
 
 write "Hello, world"
-write close
+write abort
 

--- a/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/reset.http2.stream/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/http2/streams/rfc7540/connection.management/reset.http2.stream/server.rpt
@@ -38,4 +38,4 @@ connected
 
 read "Hello, world"
 
-read closed
+read aborted


### PR DESCRIPTION
RST_STREAM should ABORT the highlevel http stream (removing END_STREAM
flag so that the stream is not HALF_CLOSED_REMOTE state)